### PR TITLE
error checking for arguments

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -2,13 +2,25 @@ package command
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
 type Command struct {
 	Command   string
 	Arguments []string
+}
+
+type IntegerArg struct {
+	LowerLimit int
+	UpperLimit int
+}
+
+type RegexArg struct {
+	Expression   string
+	CaptureGroup int
 }
 
 var prefix = "."
@@ -33,10 +45,58 @@ func IsCommand(c *Command, name string) bool {
 	return c.Command == name
 }
 
-func VerifyArguments(c *Command, count int) error {
-	// TODO: find a way to provide expected limitations for each argument
-	if len(c.Arguments) != count {
+func VerifyArguments(c *Command, args ...interface{}) error {
+	if len(c.Arguments) != len(args) {
 		return errors.New(c.Command + ": Incorrect command arguments")
 	}
+
+	for i, arg := range args {
+		switch t := arg.(type) {
+		case int:
+			_, err := strconv.ParseInt(c.Arguments[i], 10, 64)
+			if err != nil {
+				return printArgError(c.Command, c.Arguments[i], "is not a number")
+			}
+
+		case string:
+			if t != c.Arguments[i] {
+				return printArgError(c.Command, c.Arguments[i], "isn't the expected argument "+t)
+			}
+
+		case IntegerArg:
+			n, err := strconv.Atoi(c.Arguments[i])
+			if err != nil || n < t.LowerLimit || n > t.UpperLimit {
+				return printArgError(c.Command, c.Arguments[i], "is not a number between"+strconv.Itoa(t.LowerLimit)+
+					" and "+strconv.Itoa(t.UpperLimit))
+			}
+
+		case RegexArg:
+			re, err := regexp.Compile(t.Expression)
+			if err != nil {
+				return printError(c.Command, "Internal error. Regex for argument["+strconv.Itoa(i)+"] can't be compiled")
+			}
+
+			matches := re.FindStringSubmatch(c.Arguments[i])
+			if len(matches) == 0 {
+				return printArgError(c.Command, c.Arguments[i], "is not a valid argument")
+			}
+
+			// Export desired capture-group
+			c.Arguments[i] = matches[t.CaptureGroup]
+
+		default:
+			return printError(c.Command, "Internal error")
+
+		}
+	}
+
 	return nil
+}
+
+func printError(command string, cause string) error {
+	return fmt.Errorf("%s: %s", command, cause)
+}
+
+func printArgError(command string, argument string, cause string) error {
+	return printError(command, fmt.Sprintf("Argument \"%s\" %s", argument, cause))
 }

--- a/responder/responder.go
+++ b/responder/responder.go
@@ -41,9 +41,9 @@ func messageCreated(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	// If the message is "ping" reply with "Pong!"
 	if command.IsCommand(&cmd, "Zasielkovna") {
-		err := command.VerifyArguments(&cmd, 0)
+		err := command.VerifyArguments(&cmd)
 		if err != nil {
-			println(err.Error())
+			s.ChannelMessageSend(m.ChannelID, err.Error())
 			return
 		}
 		s.ChannelMessageSend(m.ChannelID, "OVER 200% <a:medzernikShake:814055147583438848>")
@@ -51,20 +51,19 @@ func messageCreated(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	// If the message is "pong" reply with "Ping!"
 	if command.IsCommand(&cmd, "pong") {
-		err := command.VerifyArguments(&cmd, 0)
+		err := command.VerifyArguments(&cmd)
 		if err != nil {
-			println(err.Error())
+			s.ChannelMessageSend(m.ChannelID, err.Error())
 			return
 		}
 		s.ChannelMessageSend(m.ChannelID, "Ping!")
 	}
 
 	//a personal reward for our founder of the server that tracks his time on the guild
-	//TODO: implement a user-inspecific argument way of checking a specific users' time on the guild
 	if command.IsCommand(&cmd, "age") {
-		err := command.VerifyArguments(&cmd, 1)
+		err := command.VerifyArguments(&cmd, command.RegexArg{`^<@!(\d+)>$`, 1})
 		if err != nil {
-			println(err.Error())
+			s.ChannelMessageSend(m.ChannelID, err.Error())
 			return
 		}
 
@@ -106,9 +105,9 @@ func messageCreated(s *discordgo.Session, m *discordgo.MessageCreate) {
 	//TODO: implement a raid protection checker that checks every 1 hour for accounts <2 hours of age and if finds more than 5 -> alert the admins
 	//TODO: change the output message to be a single message in a single output to protect from spam. Change the information.
 	if command.IsCommand(&cmd, "check-users") {
-		err := command.VerifyArguments(&cmd, 0)
+		err := command.VerifyArguments(&cmd)
 		if err != nil {
-			println(err.Error())
+			s.ChannelMessageSend(m.ChannelID, err.Error())
 			return
 		}
 


### PR DESCRIPTION
Error checking for some basic argument types.

Usage:
```
err := command.VerifyArguments(
    &cmd,
    "text",
    5,
    command.RegexArg{`123(\w+)123`, 1},
    command.IntegerArg{0,5})

if err != nil {
    s.ChannelMessageSend(m.ChannelID, err.Error())
    return
}
```

This code would expect 4 arguments in the following order: "text", 5, 123something123 and a number between (including) 0 and (including) 5

As for regexes:
regex: ```command.RegexArg{`123(\w+)123`, 1}```
input: 123something123
output: something
reason: (\w+) is capture group 1, which is the second supplied argument to RegexArg

If command doesn't expect any argument, then use `command.VerifyArguments(&cmd)`